### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
         run : |
           npm i
       - name: Publish service image to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.SERVICE_IMAGE }}
           username: ${{ secrets.DOCKER_LOGIN }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore